### PR TITLE
Array shift is using reference argument

### DIFF
--- a/src/Sudo/Main.php
+++ b/src/Sudo/Main.php
@@ -133,7 +133,8 @@ class Main extends PluginBase implements Listener{
                 $sender->sendMessage("§e操控系統 §b>　§d請輸入玩家ID 和 指令");
                 return true;
             }
-            $player = $this->getServer()->getPlayer(array_shift($args));
+	    array_shift($args);
+            $player = $this->getServer()->getPlayer($args);
             if ($player instanceof Player) {
                 $this->getServer()->dispatchCommand($player, trim(implode(" ", $args)));
                 return true;


### PR DESCRIPTION
Array shift is using **reference argument** instead of returning the shifted array, **the thing that it returning is the element that got shift out**.